### PR TITLE
A bunch of cleaning up in progress.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-protocol-parser"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
1. ~~Rework the Result type. Since we are always returning the same thing, just do that.~~
2. ~~Rework Error type so that it is actually useful.
This will additionally (possibly) introduce performance improvements because we use lesser
stack to maintain the size of the slice --- but we do have to keep around the index.~~
3. Actually handle Nil types.
Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>